### PR TITLE
Added the sender's address. Swiftmailer needs one.

### DIFF
--- a/src/Themonkeys/ErrorEmailer/ErrorEmailer.php
+++ b/src/Themonkeys/ErrorEmailer/ErrorEmailer.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Themonkeys\ErrorEmailer;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Config;
 use Symfony\Component\Debug\Exception\FlattenException;
 use Illuminate\Support\Facades\Mail;
@@ -10,6 +11,15 @@ use Illuminate\Support\Facades\View;
 class ErrorEmailer {
     public function sendException($exception)
     {
+		// From
+		$from = Config::get("error-emailer::from");
+		if (!isset($from['address'])) {
+			App::fatal(function ($exception) {
+               return 'Cannot send message without a sender address';
+			});
+		}
+
+		// To
         $recipients = Config::get("error-emailer::to");
         if (isset($recipients['address'])) {
             // this is a single recipient
@@ -37,6 +47,8 @@ class ErrorEmailer {
             Mail::send('error-emailer::error', $model, function($message) use ($model, $recipients) {
                 $subject = View::make('error-emailer::subject', $model)->render();
 
+				$message->from($from['address'], $from['name']);
+
                 $message->subject($subject);
                 foreach ($recipients as $to) {
                     $message->to($to['address'], $to['name']);
@@ -44,4 +56,4 @@ class ErrorEmailer {
             });
         }
     }
-} 
+}

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -22,6 +22,19 @@ return array(
         '404' => true,
     ),
 
+
+	 /*
+    |--------------------------------------------------------------------------
+    | Error email sender
+    |--------------------------------------------------------------------------
+    |
+    | Email stack traces from these address.
+    |
+    |   'from' => array('address' => 'you@domain.com', 'name' => 'Your Name'),
+    */
+
+    'from' => array('address' => null, 'name' => null),
+
     /*
     |--------------------------------------------------------------------------
     | Error email recipients


### PR DESCRIPTION
Adding the senders address to the email.

This solves the following error:
Error in exception handler: Cannot send message without a sender address in /var/www/studyflow/vendor/swiftmailer/swiftmailer/lib/classes/Swift/Transport/AbstractSmtpTransport.php:164
