### PR TITLE
ignoring errors from crawler bots

### DIFF
--- a/src/Themonkeys/ErrorEmailer/ErrorEmailer.php
+++ b/src/Themonkeys/ErrorEmailer/ErrorEmailer.php
@@ -10,38 +10,54 @@ use Illuminate\Support\Facades\View;
 class ErrorEmailer {
     public function sendException($exception)
     {
-        $recipients = Config::get("error-emailer::to");
-        if (isset($recipients['address'])) {
-            // this is a single recipient
-            if ($recipients['address']) {
-                $recipients = array($recipients);
-            } else {
-                $recipients = array();
-            }
-        }
-
-        if (sizeof($recipients) > 0) {
-            if ($exception instanceof FlattenException) {
-                $flattened = $exception;
-            } else {
-                $flattened = FlattenException::create($exception);
-            }
-            $handler = new ExceptionHandler();
-            $content = $handler->getContent($flattened);
-
-            $model = array(
-                'trace' => $content,
-                'exception' => $exception,
-                'flattened' => $flattened
-            );
-            Mail::send('error-emailer::error', $model, function($message) use ($model, $recipients) {
-                $subject = View::make('error-emailer::subject', $model)->render();
-
-                $message->subject($subject);
-                foreach ($recipients as $to) {
-                    $message->to($to['address'], $to['name']);
+        if(!errorFromBot()) {
+            $recipients = Config::get("error-emailer::to");
+            if (isset($recipients['address'])) {
+                // this is a single recipient
+                if ($recipients['address']) {
+                    $recipients = array($recipients);
+                } else {
+                    $recipients = array();
                 }
-            });
+            }
+
+            if (sizeof($recipients) > 0) {
+                if ($exception instanceof FlattenException) {
+                    $flattened = $exception;
+                } else {
+                    $flattened = FlattenException::create($exception);
+                }
+                $handler = new ExceptionHandler();
+                $content = $handler->getContent($flattened);
+
+                $model = array(
+                    'trace' => $content,
+                    'exception' => $exception,
+                    'flattened' => $flattened
+                );
+                Mail::send('error-emailer::error', $model, function($message) use ($model, $recipients) {
+                    $subject = View::make('error-emailer::subject', $model)->render();
+
+                    $message->subject($subject);
+                    foreach ($recipients as $to) {
+                        $message->to($to['address'], $to['name']);
+                    }
+                });
+            }
         }
+    }
+
+    protected static function errorFromBot() {
+        $ignoredBots = Config::get("error-emailer::ignoredBots");
+        $serverUserAgent = array_key_exists('HTTP_USER_AGENT', $_SERVER) ? $_SERVER['HTTP_USER_AGENT'] : null;
+        $serverFrom = array_key_exists('HTTP_FROM', $_SERVER) ? $_SERVER['HTTP_FROM'] : null;
+        if(is_array($ignoredBots)) {
+            foreach ($ignoredBots as $bot) {
+                if( ($serverUserAgent && strpos(strtolower($serverUserAgent), $bot) !== false) || ($serverFrom && strpos(strtolower($serverFrom), $bot) !== false) )
+                    return true;
+            }
+        }
+
+        return false;
     }
 } 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -41,4 +41,20 @@ return array(
     */
 
     'to' => array('address' => null, 'name' => null),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Ignore Crawler Bots
+    |--------------------------------------------------------------------------
+    |
+    | For which bots should we NOT send error emails?
+    |
+    */
+    'ignoredBots' => array(
+        'googlebot',        //Googlebot
+        'bingbot',          //Microsoft Bingbot
+        'slurp',            //Yahoo! Slurp
+        'AhrefsBot',        //AhrefsBot
+        'ia_archiver',      //crawler@alexa.com
+    ),
 );


### PR DESCRIPTION
Added optional ignoring of crawler bots for your mails.

This prevents your mailbox from being overloaded with errors that were generated on (for example) non-existing pages.

error example:
`[HTTP_FROM] => googlebot(at)googlebot.com`
or
`[HTTP_USER_AGENT] => Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)`

Simply add the bots you want to ignore to the config file - If you don't want to ignore any bots: just leave the array empty
